### PR TITLE
Modified run() to pass returnCode to main() and as the final exit code

### DIFF
--- a/src/ebcdic_parser/convert.py
+++ b/src/ebcdic_parser/convert.py
@@ -1036,7 +1036,7 @@ def run(inputFile,
         if dataConverter!=None:
             dataConverter.release()
                 
-        sys.exit(returnCode)
+        return returnCode
 
 def main():
     returnCode = 1
@@ -1129,21 +1129,21 @@ def main():
         
         print("-----------------------------------")
         print()
-        
-        run(filePath, 
-            outputFolder, 
-            layoutPath, 
-            args.logfolder, 
-            PYTHONENCODING, 
-            INPUTENCODING, 
-            DELIMITER, 
-            OUTPUTFILEEXTENSION, 
-            IGNORECONVERSIONERRORS, 
-            GROUPRECORDS, 
-            GROUPRECORDSLEVEL2, 
-            VERBOSE, 
-            DEBUG_MODE,
-            cliMode=True)
+
+        returnCode = run(filePath,
+                         outputFolder,
+                         layoutPath,
+                         args.logfolder,
+                         PYTHONENCODING,
+                         INPUTENCODING,
+                         DELIMITER,
+                         OUTPUTFILEEXTENSION,
+                         IGNORECONVERSIONERRORS,
+                         GROUPRECORDS,
+                         GROUPRECORDSLEVEL2,
+                         VERBOSE,
+                         DEBUG_MODE,
+                         cliMode=True)
          
     except KnownIssue as descr:
         print(descr)


### PR DESCRIPTION
Problem Description:
- When calling the parser from a shell script. Even on a Successful parse, the final exit code was 1.

Fix:
- run() has been modified to return the returnCode to main. 
- main() has been modified to capture the returnCode from run() and finally pass it as System Exit Code